### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,6 +1,6 @@
 class ProductsController < ApplicationController
-  before_action :set_product, only: [:edit, :update, :show]
-  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :set_product, only: [:edit, :update, :show, :destroy]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
 
   def index
     @products = Product.order("created_at DESC")
@@ -39,6 +39,11 @@ class ProductsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @product.destroy
+    redirect_to '/'
   end
 
   private

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -42,8 +42,10 @@ class ProductsController < ApplicationController
   end
 
   def destroy
-    @product.destroy
-    redirect_to '/'
+    if user_signed_in? && Product.find(params[:id]).user_id == current_user.id
+      @product.destroy
+      redirect_to '/'
+    end
   end
 
   private

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -26,7 +26,7 @@
       <% if current_user.id == @product.user_id %>
         <%= link_to "商品の編集", edit_product_path(@product.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", product_path(@product.id), data: { turbo_method: :delete }, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   #get 'items', to: 'items#index'
   #post 'items/new', to: 'items#new'
   ##resources :items, only: [:index, :new, :create]
-  resources :products, only: [:index, :new, :create, :show, :edit, :update]
+  resources :products, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 
   ##resources :products
 end


### PR DESCRIPTION
# what
商品削除機能の実装

# why
出品した商品を削除したいため

# gyazo
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/1abf6a4ada5957dda4aec3b0155706bf